### PR TITLE
Update RCTImageLoader.m

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -332,7 +332,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
         completionHandler(error, nil);
         return;
       }
-      if(!response)
+      if(response == nil)
       {
         completionHandler([NSError errorWithDomain:RCTErrorDomain code:0
         userInfo:@{NSLocalizedDescriptionKey: @"the response is nil."}], nil);


### PR DESCRIPTION
fix this crash when the image download error:

0 CoreFoundation 0x0000000185d62580 CFRetain + 164
1 CFNetwork 0x00000001857c2174 **CFCachedURLResponse::__CFCachedURLResponse(_CFURLResponse_, __CFData const_, void const*, CFURLCacheStoragePolicy) + 80
2 CFNetwork 0x00000001857c20cc CFCachedURLResponseCreateWithUserInfo + 120
3 CFNetwork 0x00000001858c7a34 -[NSCachedURLResponse initWithResponse:data:userInfo:storagePolicy:] + 328
4 Qzone 0x000000010026b3b8 __87-[RCTImageLoader loadImageWithTag:size:scale:resizeMode:progressBlock:completionBlock:]_block_invoke_2.195 (RCTImageLoader.m:292)
5 Qzone 0x00000001002630fc -[RCTNetworkTask URLRequest:didCompleteWithError:](RCTNetworkTask.m:132)
6 Qzone 0x0000000100268074 -[RCTHTTPRequestHandler URLSession:task:didCompleteWithError:](RCTHTTPRequestHandler.m:114)
7 CFNetwork 0x00000001858c46a8 ___51-[NSURLSession delegate_task:didCompleteWithError:]_block_invoke227 + 64
8 Foundation 0x0000000186d6f1c4 ___NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK** + 16
9 Foundation 0x0000000186cc0604 -[NSBlockOperation main] + 96
10 Foundation 0x0000000186cb01cc -[__NSOperationInternal _start:] + 636
11 Foundation 0x0000000186d71f28 ___NSOQSchedule_f + 228
17 libdispatch.dylib 0x00000001981d1954 __dispatch_client_callout + 16
23 libdispatch.dylib 0x00000001981dc0a4 __dispatch_queue_drain + 1448
24 libdispatch.dylib 0x00000001981d4a5c __dispatch_queue_invoke + 132
25 libdispatch.dylib 0x00000001981de318 __dispatch_root_queue_drain + 720
26 libdispatch.dylib 0x00000001981dfc4c __dispatch_worker_thread3 + 108
27 libsystem_pthread.dylib 0x00000001983b121c _pthread_wqthread + 804
1 libsystem_pthread.dylib 0x00000001983b0ee0 start_wqthread + 4
